### PR TITLE
chore: adiciona arquivo '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+### C++ ###
+
+.vscode/
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# End of https://www.toptal.com/developers/gitignore/api/c++


### PR DESCRIPTION
Este commit adiciona o arquivo '.gitignore' ao projeto para garantir que arquivos desnecessários, como arquivos temporários ou de configuração específicos do ambiente, não sejam incluídos no controle de versão.